### PR TITLE
fix: void and infer type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -214,10 +214,7 @@ class Context {
 
     if (type.flags & TypeFlags.TypeParameter) {
       let name = type.symbol.name, found = this.typeParams.find(p => p.name == name)
-      if (!found) {
-        return {type: name, typeParamSource: 'missing'}
-      }
-      return {type: name, typeParamSource: found.id}
+      return {type: name, typeParamSource: found ? found.id : "missing"}
     }
 
     if (type.flags & TypeFlags.Index) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -215,7 +215,7 @@ class Context {
     if (type.flags & TypeFlags.TypeParameter) {
       let name = type.symbol.name, found = this.typeParams.find(p => p.name == name)
       if (!found) {
-        return {type: name, typeSource: 'missing'}
+        return {type: name, typeParamSource: 'missing'}
       }
       return {type: name, typeParamSource: found.id}
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -182,6 +182,7 @@ class Context {
     if (type.flags & TypeFlags.Boolean) return {type: "boolean"}
     if (type.flags & TypeFlags.Undefined) return {type: "undefined"}
     if (type.flags & TypeFlags.Null) return {type: "null"}
+    if (type.flags & TypeFlags.Void) return {type: "void"}
     // FIXME TypeScript doesn't export this. See https://github.com/microsoft/TypeScript/issues/26075, where they intend to fix that
     if (type.flags & TypeFlags.BooleanLiteral) return {type: (type as any).intrinsicName}
     if (type.flags & TypeFlags.Literal) return {type: JSON.stringify((type as LiteralType).value)}
@@ -213,7 +214,9 @@ class Context {
 
     if (type.flags & TypeFlags.TypeParameter) {
       let name = type.symbol.name, found = this.typeParams.find(p => p.name == name)
-      if (!found) throw new Error(`Unknown type parameter ${name}`)
+      if (!found) {
+        return {type: name, typeSource: 'missing'}
+      }
       return {type: name, typeParamSource: found.id}
     }
 


### PR DESCRIPTION
This PR fix two cases which will cause error now:

```ts
// 1. void type will cause error
const fn = (): void => {}

// 2. infer type will cause error
type InferParams<T> = T extends Array<infer U> ? U : never;
```